### PR TITLE
Replace hyperx with minimal, vendored Content-Range parsing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ bytes = "1.1.0"
 futures = "0.3.25"
 hex = "0.4.3"
 http = "0.2.8"
-hyperx = { version = "1.4.0", features = ["headers"] }
 md-5 = "0.10.5"
 reqwest = { version = "0.11.13", features = ["json"] }
 reqwest-middleware = "0.1.6"


### PR DESCRIPTION
This removes the `hyperx` (https://github.com/dekellum/hyperx) dependency, because that dependencies takes the unusual approach of putting strict _upper_ bounds on dependencies (not just restricting to semver-compatible versions, as Cargo does by default), and seems to be relatively unmaintained: a fix https://github.com/dekellum/hyperx/pull/40 for that issue hasn't been merged for a while.

This dependency is only used to parse the `Content-Range` header value. This header is very simple, and thus it's easy to implement what's required directly in `gha-toolkit`.

Similar to https://github.com/BitskiCo/gha-toolkit/pull/6, removing this dependency makes integrating `gha-toolkit` into other projects much easier. For example, in https://github.com/pantsbuild/pants/pull/17840, I had use Cargo's `[patch.crates-io]` directive to refer to https://github.com/dekellum/hyperx/pull/40, or else cargo couldn't find a valid set of dependencies (that is, I literally couldn't add `gha-toolkit` as a dependency due to `hyperx`).

This also positively improves the transitive dependencies of `gha-toolkit` too:

- `language-tags` and `matches` are no longer required (i.e. the dependency tree/compile times is smaller)
- `bytes`, `form_urlencoded`, `idna`, `percent-encoding`, `url` can use newer versions, since `hyperx`'s upper bounds have disappeared
